### PR TITLE
Fix for new Firefox private browsing API.

### DIFF
--- a/content/voyage.js
+++ b/content/voyage.js
@@ -26,9 +26,8 @@ var voyage = {
     XPCOMUtilsExtra.defineLazyServiceGetter(this, "_faviconService", "@mozilla.org/browser/favicon-service;1", "nsIFaviconService");
 
     /* Find out if we are in private browsing mode, if true, display error message */
-    var privateSvc = Cc["@mozilla.org/privatebrowsing;1"].getService(Ci.nsIPrivateBrowsingService);  
-    this.inPrivate = privateSvc.privateBrowsingEnabled;  
-  },
+    var privateSvc = Components.utils.import("resource://gre/modules/PrivateBrowsingUtils.jsm");
+    this.inPrivate = PrivateBrowsingUtils.isWindowPrivate(window);  },
   onDOMReady: function() {
     if (this.inPrivate) {
       $('#container').remove();


### PR DESCRIPTION
 Recommended by SCY

https://addons.mozilla.org/en-US/firefox/addon/voyage/reviews/527700/

> Because of Firefox 20 introduced per-window private browsing mode. So the old API was discreated.
> See https://developer.mozilla.org/EN/docs/Supporting_per-window_private_browsing
> 
> How to solve the problem:
> 1. Download source code from https://github.com/littlebtc/voyage that was uploaded by author.
> 2. Extract zip file and open {source folder}/content/voyage.js
> 3. Find code at line 29, 30:
> line 29: var privateSvc = Cc["@mozilla.org/privatebrowsing;1"].getService(Ci.nsIPrivateBrowsingService);
> line 30: this.inPrivate = privateSvc.privateBrowsingEnabled;
> And replace to:
> line 29: var privateSvc = Components.utils.import("resource://gre/modules/PrivateBrowsingUtils.jsm");
> line 30: this.inPrivate = PrivateBrowsingUtils.isWindowPrivate(window);
> 4. Compress all file in the {source folder} use zip file format. Change extension .zip to .xpi. (Or you can use this shell script http://sharetext.org/iQr to create a XPI file. I copied the shell script from author's other add-on NicoFox and modified it.)
> 5. Install XPI to Firefox.
> 6. Congratulation!!
> 
> Test on Firefox 27.0b2
